### PR TITLE
Make Trinkets an optional dependency, add offhand support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.14.0
+
+- Trinkets is now an optional dependency
+
+Functional changes:
+- You can now cast spells from the Spell Book in your offhand (server configurable)
+
 # 0.13.0
 
 API changes:

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {
 
     modImplementation("dev.kosmx.player-anim:player-animation-lib-fabric:${project.player_anim_version}")
     modImplementation("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}")
-    modImplementation("dev.emi:trinkets:${project.trinkets_version}")
 
     modImplementation("maven.modrinth:spell-power:${project.spell_power_version}-fabric")
     modImplementation("maven.modrinth:projectile-damage-attribute:${project.projectile_version}-fabric")
@@ -62,6 +61,7 @@ dependencies {
     // Compatibility
     modImplementation("com.terraformersmc:modmenu:${project.mod_menu_version}")
     modImplementation("curse.maven:shoulder-surfing-reloaded-243190:${shoulder_surfing_file_id}")
+    modCompileOnly("dev.emi:trinkets:${project.trinkets_version}")
     modCompileOnly("maven.modrinth:first-person-model:${project.fpm_version}")
     modCompileOnly("maven.modrinth:supplementaries:${project.supplementaries_version}")
     modCompileOnly("maven.modrinth:iris:${project.iris_version}")
@@ -136,7 +136,7 @@ if(project.hasProperty('release_type')) {
                 requiredDependency 'cloth-config'
                 requiredDependency 'playeranimator'
                 requiredDependency 'spell-power'
-                requiredDependency 'trinkets'
+                optionalDependency 'trinkets'
             }
 
             mainArtifact(remapJar)
@@ -167,7 +167,7 @@ if(project.hasProperty('release_type')) {
             required.project 'cloth-config'
             required.project 'playeranimator'
             required.project 'spell-power'
-            required.project 'trinkets'
+            optional.project 'trinkets'
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ fabric_api_version=0.87.0+1.20.1
 # Mod
 maven_group=net
 archives_base_name=spell_engine
-mod_version=0.13.0
+mod_version=0.14.0
 
 # Dependencies
 cloth_config_version=11.1.106

--- a/src/main/java/net/spell_engine/api/item/trinket/SpellBookItem.java
+++ b/src/main/java/net/spell_engine/api/item/trinket/SpellBookItem.java
@@ -1,18 +1,8 @@
 package net.spell_engine.api.item.trinket;
 
-import dev.emi.trinkets.api.TrinketItem;
-import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.util.Identifier;
 
-public class SpellBookItem extends TrinketItem {
-    public final Identifier poolId;
-    public SpellBookItem(Identifier poolId, Settings settings) {
-        super(settings);
-        this.poolId = poolId;
-    }
-
-    @Override
-    public boolean isEnchantable(ItemStack stack) {
-        return false;
-    }
+public interface SpellBookItem extends ItemConvertible {
+    Identifier getPoolId();
 }

--- a/src/main/java/net/spell_engine/api/item/trinket/SpellBookTrinketItem.java
+++ b/src/main/java/net/spell_engine/api/item/trinket/SpellBookTrinketItem.java
@@ -1,0 +1,25 @@
+package net.spell_engine.api.item.trinket;
+
+import dev.emi.trinkets.api.TrinketItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+
+public class SpellBookTrinketItem extends TrinketItem implements SpellBookItem {
+    private final Identifier poolId;
+
+    public SpellBookTrinketItem(Identifier poolId, Settings settings) {
+        super(settings);
+        this.poolId = poolId;
+    }
+
+    @Override
+    public boolean isEnchantable(ItemStack stack) {
+        return false;
+    }
+
+    @Override
+    public Identifier getPoolId() {
+        return poolId;
+    }
+
+}

--- a/src/main/java/net/spell_engine/api/item/trinket/SpellBookVanillaItem.java
+++ b/src/main/java/net/spell_engine/api/item/trinket/SpellBookVanillaItem.java
@@ -1,0 +1,23 @@
+package net.spell_engine.api.item.trinket;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+
+public class SpellBookVanillaItem extends Item implements SpellBookItem {
+    private final Identifier poolId;
+    public SpellBookVanillaItem(Identifier poolId, Settings settings) {
+        super(settings);
+        this.poolId = poolId;
+    }
+
+    @Override
+    public boolean isEnchantable(ItemStack stack) {
+        return false;
+    }
+
+    @Override
+    public Identifier getPoolId() {
+        return poolId;
+    }
+}

--- a/src/main/java/net/spell_engine/api/item/trinket/SpellBooks.java
+++ b/src/main/java/net/spell_engine/api/item/trinket/SpellBooks.java
@@ -2,12 +2,14 @@ package net.spell_engine.api.item.trinket;
 
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
 import net.spell_engine.api.spell.SpellContainer;
+import net.spell_engine.compat.TrinketsCompat;
 import net.spell_engine.internals.SpellRegistry;
 
 import java.util.ArrayList;
@@ -15,14 +17,16 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+// TODO: This class should probably be moved to net.spell_engine.api.item as it seems to be mod-agnostic
 public class SpellBooks {
     private static final ArrayList<SpellBookItem> all = new ArrayList<>();
+
     public static List<SpellBookItem> sorted() {
         return SpellBooks.all
                 .stream()
-                .sorted(Comparator.comparing(spellBookItem -> spellBookItem.poolId.toString()))
+                .sorted(Comparator.comparing(spellBookItem -> spellBookItem.getPoolId().toString()))
                 .filter(spellBookItem -> {
-                    var pool = SpellRegistry.spellPool(spellBookItem.poolId);
+                    var pool = SpellRegistry.spellPool(spellBookItem.getPoolId());
                     return pool != null && pool.craftable();
                 })
                 .collect(Collectors.toList());
@@ -35,7 +39,14 @@ public class SpellBooks {
     public static SpellBookItem create(Identifier poolId, SpellContainer.ContentType contentType) {
         var container = new SpellContainer(contentType, false, poolId.toString(), 0, List.of());
         SpellRegistry.book_containers.put(itemIdFor(poolId), container);
-        var book = new SpellBookItem(poolId, new FabricItemSettings().maxCount(1));
+        SpellBookItem book = null;
+        if (TrinketsCompat.isEnabled()) {
+            book = new SpellBookTrinketItem(poolId, new FabricItemSettings().maxCount(1));
+        }
+        // TODO: Add support for Curios
+        else {
+            book = new SpellBookVanillaItem(poolId, new FabricItemSettings().maxCount(1));
+        }
         all.add(book);
         return book;
     }
@@ -45,7 +56,11 @@ public class SpellBooks {
     }
 
     public static void register(SpellBookItem spellBook) {
-        Registry.register(Registries.ITEM, itemIdFor(spellBook.poolId), spellBook);
+        if (spellBook instanceof Item) {
+            Registry.register(Registries.ITEM, itemIdFor(spellBook.getPoolId()), (Item) spellBook);
+        } else {
+            throw new IllegalArgumentException("SpellBookItem must be an Item");
+        }
     }
 
     public static void createAndRegister(Identifier poolId, RegistryKey<ItemGroup> itemGroupKey) {
@@ -54,9 +69,7 @@ public class SpellBooks {
 
     public static void createAndRegister(Identifier poolId, SpellContainer.ContentType contentType, RegistryKey<ItemGroup> itemGroupKey) {
         var item = create(poolId, contentType);
-        ItemGroupEvents.modifyEntriesEvent(itemGroupKey).register(content -> {
-            content.add(item);
-        });
+        ItemGroupEvents.modifyEntriesEvent(itemGroupKey).register(content -> content.add(item));
         register(item);
     }
 }

--- a/src/main/java/net/spell_engine/compat/TrinketsCompat.java
+++ b/src/main/java/net/spell_engine/compat/TrinketsCompat.java
@@ -11,7 +11,9 @@ import net.spell_engine.api.item.trinket.SpellBookTrinketItem;
 import net.spell_engine.api.spell.SpellContainer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 import static net.spell_engine.internals.SpellContainerHelper.containerFromItemStack;
 
@@ -35,13 +37,13 @@ public class TrinketsCompat {
         return enabled;
     }
 
-    public static SpellContainer getEquipped(SpellContainer proxyContainer, PlayerEntity player) {
-        if (!enabled) return proxyContainer;
+    public static List<String> getEquippedSpells(SpellContainer proxyContainer, PlayerEntity player) {
+        if (!enabled) return Collections.emptyList();
 
         var component = TrinketsApi.getTrinketComponent(player);
 
         if (component.isEmpty() || proxyContainer == null || !proxyContainer.is_proxy) {
-            return proxyContainer;
+            return Collections.emptyList();
         }
 
         var trinketComponent = component.get();
@@ -56,7 +58,7 @@ public class TrinketsCompat {
         trinketComponent.getAllEquipped().forEach(pair -> items.add(pair.getRight()));
 
         // Extract spell IDs from the containers
-        var collectedSpellIds = new LinkedHashSet<String>(proxyContainer.spell_ids);
+        var collectedSpellIds = new LinkedHashSet<>(proxyContainer.spell_ids);
         for (ItemStack stack : items) {
             if (stack.isEmpty()) continue;
 
@@ -66,7 +68,7 @@ public class TrinketsCompat {
             }
         }
 
-        return new SpellContainer(allowedContent, false, null, 0, new ArrayList<>(collectedSpellIds));
+        return new ArrayList<>(collectedSpellIds);
     }
 
 

--- a/src/main/java/net/spell_engine/compat/TrinketsCompat.java
+++ b/src/main/java/net/spell_engine/compat/TrinketsCompat.java
@@ -1,0 +1,73 @@
+package net.spell_engine.compat;
+
+import dev.emi.trinkets.api.TrinketsApi;
+import net.fabricmc.fabric.api.util.TriState;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.spell_engine.SpellEngineMod;
+import net.spell_engine.api.item.trinket.SpellBookTrinketItem;
+import net.spell_engine.api.spell.SpellContainer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+
+import static net.spell_engine.internals.SpellContainerHelper.containerFromItemStack;
+
+public class TrinketsCompat {
+    private static boolean enabled = false;
+
+    public static void init() {
+        enabled = FabricLoader.getInstance().isModLoaded("trinkets");
+
+        if (enabled) {
+            TrinketsApi.registerTrinketPredicate(new Identifier(SpellEngineMod.ID, "spell_book"), (itemStack, slotReference, livingEntity) -> {
+                if (itemStack.getItem() instanceof SpellBookTrinketItem) {
+                    return TriState.TRUE;
+                }
+                return TriState.DEFAULT;
+            });
+        }
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static SpellContainer getEquipped(SpellContainer proxyContainer, PlayerEntity player) {
+        if (!enabled) return proxyContainer;
+
+        var component = TrinketsApi.getTrinketComponent(player);
+
+        if (component.isEmpty() || proxyContainer == null || !proxyContainer.is_proxy) {
+            return proxyContainer;
+        }
+
+        var trinketComponent = component.get();
+        var allowedContent = proxyContainer.content;
+        var items = new LinkedHashSet<ItemStack>();
+        var spellBookSlot = trinketComponent.getInventory().get("charm").get("spell_book");
+
+        // Add the spell book slot first
+        items.add(spellBookSlot.getStack(0));
+
+        // Add all other equipped items
+        trinketComponent.getAllEquipped().forEach(pair -> items.add(pair.getRight()));
+
+        // Extract spell IDs from the containers
+        var collectedSpellIds = new LinkedHashSet<String>(proxyContainer.spell_ids);
+        for (ItemStack stack : items) {
+            if (stack.isEmpty()) continue;
+
+            var container = containerFromItemStack(stack);
+            if (container != null && container.isValid() && container.content == allowedContent) {
+                collectedSpellIds.addAll(container.spell_ids);
+            }
+        }
+
+        return new SpellContainer(allowedContent, false, null, 0, new ArrayList<>(collectedSpellIds));
+    }
+
+
+}

--- a/src/main/java/net/spell_engine/config/ServerConfig.java
+++ b/src/main/java/net/spell_engine/config/ServerConfig.java
@@ -27,6 +27,8 @@ public class ServerConfig implements ConfigData { public ServerConfig() {}
     public int spell_book_binding_level_requirement = 3;
     @Comment("Spell book creation level cost")
     public int spell_book_binding_level_cost = 1;
+    @Comment("Should the player be able to cast spells from the offhand spell book?")
+    public boolean spell_book_offhand = true;
 
     @Comment("Apply `Spell Casting from Spell Book` capability to anything that subclasses Sword")
     public boolean add_spell_casting_to_swords = true;

--- a/src/main/java/net/spell_engine/fabric/FabricMod.java
+++ b/src/main/java/net/spell_engine/fabric/FabricMod.java
@@ -1,10 +1,8 @@
 package net.spell_engine.fabric;
 
-import dev.emi.trinkets.api.TrinketsApi;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
-import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.EntityDimensions;
 import net.minecraft.entity.SpawnGroup;
 import net.minecraft.registry.Registries;
@@ -12,7 +10,7 @@ import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 import net.spell_engine.SpellEngineMod;
 import net.spell_engine.api.effect.RemoveOnHit;
-import net.spell_engine.api.item.trinket.SpellBookItem;
+import net.spell_engine.compat.TrinketsCompat;
 import net.spell_engine.entity.SpellCloud;
 import net.spell_engine.entity.SpellProjectile;
 import net.spell_engine.utils.SoundHelper;
@@ -48,17 +46,12 @@ public class FabricMod implements ModInitializer {
         SpellEngineMod.registerSpellBinding();
         SoundHelper.registerSounds();
 
-        TrinketsApi.registerTrinketPredicate(new Identifier(SpellEngineMod.ID, "spell_book"), (itemStack, slotReference, livingEntity) -> {
-            if (itemStack.getItem() instanceof SpellBookItem) {
-                return TriState.TRUE;
-            }
-            return TriState.DEFAULT;
-        });
+        TrinketsCompat.init();
 
         ServerLivingEntityEvents.ALLOW_DAMAGE.register((entity, source, amount) -> {
             var attacker = source.getAttacker();
             if (amount > 0 && attacker != null) {
-                for(var instance: entity.getStatusEffects()) {
+                for (var instance : entity.getStatusEffects()) {
                     var effect = instance.getEffectType();
                     if (RemoveOnHit.shouldRemoveOnDirectHit(effect)) {
                         entity.removeStatusEffect(effect);

--- a/src/main/java/net/spell_engine/internals/SpellContainerHelper.java
+++ b/src/main/java/net/spell_engine/internals/SpellContainerHelper.java
@@ -55,15 +55,26 @@ public class SpellContainerHelper {
     }
 
     private static boolean isOffhandContainerValid(PlayerEntity player, SpellContainer.ContentType allowedContent) {
-        SpellContainer container = containerFromItemStack(player.getOffHandStack());
+        ItemStack offhandItemStack = getOffhandItemStack(player);
+        SpellContainer container = containerFromItemStack(offhandItemStack);
         return container != null && container.isValid() && container.content == allowedContent;
     }
 
     private static List<String> getOffhandSpellIds(PlayerEntity player) {
-        SpellContainer container = containerFromItemStack(player.getOffHandStack());
+        ItemStack offhandItemStack = getOffhandItemStack(player);
+        SpellContainer container = containerFromItemStack(offhandItemStack);
         if (container == null) return Collections.emptyList();
 
         return container.spell_ids;
+    }
+
+    /**
+     * Get the item stack in the offhand slot of the player's inventory
+     * This method is used for BetterCombat mod compatibility.
+     * BetterCombat overrides player.getOffHandStack() to return empty stack when player is dual wielding.
+     */
+    private static ItemStack getOffhandItemStack(PlayerEntity player) {
+        return player.getInventory().offHand.get(0);
     }
 
     public static SpellContainer containerFromItemStack(ItemStack itemStack) {

--- a/src/main/java/net/spell_engine/spellbinding/SpellBindingScreen.java
+++ b/src/main/java/net/spell_engine/spellbinding/SpellBindingScreen.java
@@ -267,7 +267,7 @@ public class SpellBindingScreen extends HandledScreen<SpellBindingScreenHandler>
                         var button = new ButtonViewModel(shown,
                                 originX + BUTTONS_ORIGIN_X, originY + BUTTONS_ORIGIN_Y + ((buttons.size() - pageOffset) * BUTTON_HEIGHT),
                                 BUTTON_WIDTH, BUTTON_HEIGHT,
-                                isEnabled, null, item, bindingState);
+                                isEnabled, null, (Item) item, bindingState);
                         buttons.add(button);
                     }
                 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,7 +38,9 @@
     "fabric": ">=${fabric_api_version}",
     "cloth-config": ">=${cloth_config_version}",
     "player-animator": ">=0.9.9",
-    "spell_power": ">=${spell_power_version}",
+    "spell_power": ">=${spell_power_version}"
+  },
+  "recommends": {
     "trinkets": "*"
   },
   "custom": {


### PR DESCRIPTION
https://github.com/ZsoltMolnarrr/SpellEngine/assets/3682284/d400cd83-1c38-4bbd-91c1-f59e5cb517b7

## This PR


* Decouples all trinkets related code, allowing mod to be used without it
* Adds support for using spell books from offhand slot
* Marks Trinkets as optional dependency 
* Adds a config value to allow / restrict usage of spell book from offhand

All trinkets related code was moved into `TrinketsCompat` class, it also provides vanilla alternative for `SpellBookItem extends TrinketItem` by introducing common interface and separated implementations.

Offhand slot is read via player's inventory rather than `getOffhandStack` or similar functions, to allow to read spell book from offhand slot even with Better Combat mod installed (as BetterCombat overrides offhand methods with Mixins to return empty stack when dualwielding) 

### Why?

Since RPG Series are now compatible with Forge, thanks to Sinytra Connector, having hard-dependency on Trinkets forces users who want to have access to wider list of mods to install both slots APIs (Trinkets & Curious), which leads to a whole list of unwanted side-effects, such as duplicated slots from mods that do support both of those APIs, disappearing or duplicating books, etc (Aether as an good example of such mod)  

This also allows mod to be used on more vanilla modpacks or simply with other mods where modifying inventory screen might cause incompatibility 

Aside of that, with trinkets decoupled and grouped into it's own file, it would be easier to integrate any other API (Like Curious) in the future
