### PR TITLE
[1.19.2] Migrate Shoulder Surfing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.27
+
+Functional changes:
+- Migrate to latest API of Shoulder Surfing
+
 # 0.9.26
 
 -  Fix right click to use abilities for blacklisted items

--- a/common/src/main/java/net/spell_engine/client/compatibility/ShoulderSurfingCompatibility.java
+++ b/common/src/main/java/net/spell_engine/client/compatibility/ShoulderSurfingCompatibility.java
@@ -1,7 +1,7 @@
 package net.spell_engine.client.compatibility;
 
-import com.teamderpy.shouldersurfing.api.IShoulderSurfingPlugin;
-import com.teamderpy.shouldersurfing.api.IShoulderSurfingRegistrar;
+import com.github.exopandora.shouldersurfing.api.IShoulderSurfingPlugin;
+import com.github.exopandora.shouldersurfing.api.IShoulderSurfingRegistrar;
 import net.spell_engine.internals.SpellContainerHelper;
 
 public class ShoulderSurfingCompatibility implements IShoulderSurfingPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,5 +25,5 @@ trinkets_version=3.4.1
 
 # Compatibility
 mod_menu_version=4.0.6
-shoulder_surfing_file_id=4377282
+shoulder_surfing_file_id=5249522
 fpm_version=2.1.2-fabric-1.19


### PR DESCRIPTION
Migrates the Shoulder Surfing API for the 1.19.2 branch, as I got several reports of game crashes.