### PR TITLE
New feature: Added proxy_pool to SpellContainer

### DIFF
--- a/src/main/java/net/spell_engine/api/item/trinket/SpellBooks.java
+++ b/src/main/java/net/spell_engine/api/item/trinket/SpellBooks.java
@@ -36,7 +36,7 @@ public class SpellBooks {
     }
 
     public static SpellBookItem create(Identifier poolId, SpellContainer.ContentType contentType) {
-        var container = new SpellContainer(contentType, false, poolId.toString(), 0, List.of());
+        var container = new SpellContainer(contentType, false, null, poolId.toString(), 0, List.of());
         SpellRegistry.book_containers.put(itemIdFor(poolId), container);
         SpellBookItem book = null;
         TrinketsCompat.init();

--- a/src/main/java/net/spell_engine/api/spell/SpellContainer.java
+++ b/src/main/java/net/spell_engine/api/spell/SpellContainer.java
@@ -6,7 +6,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-public record SpellContainer(ContentType content, boolean is_proxy, String pool, int max_spell_count, List<String> spell_ids) {
+public record SpellContainer(ContentType content, boolean is_proxy, String proxy_pool, String pool, int max_spell_count, List<String> spell_ids) {
     public enum ContentType {
         MAGIC, ARCHERY;
         public static Codec<ContentType> CODEC = Codec.STRING.xmap(ContentType::valueOf, ContentType::name);
@@ -15,15 +15,17 @@ public record SpellContainer(ContentType content, boolean is_proxy, String pool,
     public static final Codec<SpellContainer> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             ContentType.CODEC.optionalFieldOf("content", ContentType.MAGIC).forGetter(x -> x.content),
             Codec.BOOL.optionalFieldOf("is_proxy", false).forGetter(x -> x.is_proxy),
+            Codec.STRING.optionalFieldOf("proxy_pool", "").forGetter(x -> x.proxy_pool),
             Codec.STRING.optionalFieldOf("pool", "").forGetter(x -> x.pool),
             Codec.INT.optionalFieldOf("max_spell_count", 0).forGetter(x -> x.max_spell_count),
             Codec.STRING.listOf().optionalFieldOf("spell_ids", List.of()).forGetter(x -> x.spell_ids)
     ).apply(instance, SpellContainer::new));
 
     // Canonical constructor with default values, to avoid null values
-    public SpellContainer(ContentType content, boolean is_proxy, String pool, int max_spell_count, List<String> spell_ids) {
+    public SpellContainer(ContentType content, boolean is_proxy, String proxy_pool, String pool, int max_spell_count, List<String> spell_ids) {
         this.content = content != null ? content : ContentType.MAGIC;
         this.is_proxy = is_proxy;
+        this.proxy_pool = proxy_pool != null ? proxy_pool : "";
         this.pool = pool != null ? pool : "";
         this.max_spell_count = max_spell_count;
         this.spell_ids = spell_ids != null ? spell_ids : List.of();
@@ -60,10 +62,10 @@ public record SpellContainer(ContentType content, boolean is_proxy, String pool,
     }
 
     public SpellContainer copy() {
-        return new SpellContainer(content, is_proxy, pool, max_spell_count, new ArrayList<>(spell_ids));
+        return new SpellContainer(content, is_proxy, proxy_pool, pool, max_spell_count, new ArrayList<>(spell_ids));
     }
 
     public SpellContainer copyWith(List<String> spell_ids) {
-        return new SpellContainer(content, is_proxy, pool, max_spell_count, spell_ids);
+        return new SpellContainer(content, is_proxy, proxy_pool, pool, max_spell_count, spell_ids);
     }
 }

--- a/src/main/java/net/spell_engine/internals/SpellContainerHelper.java
+++ b/src/main/java/net/spell_engine/internals/SpellContainerHelper.java
@@ -40,6 +40,11 @@ public class SpellContainerHelper {
         // Using LinkedHashSet to preserve order and remove duplicates
         var spellIds = new LinkedHashSet<>(proxyContainer.spell_ids());
 
+        SpellPool proxySpellPool = SpellPool.empty;
+        if (proxyContainer.proxy_pool() != null && !proxyContainer.proxy_pool().isEmpty()) {
+            proxySpellPool = SpellRegistry.spellPool(Identifier.of(proxyContainer.proxy_pool()));
+        }
+
         if (TrinketsCompat.isEnabled()) {
             spellIds.addAll(TrinketsCompat.getEquippedSpells(proxyContainer, player));
         }
@@ -75,12 +80,19 @@ public class SpellContainerHelper {
                             toRemove.add(other.id().toString());
                         }
                     }
+
+                    // remove spells not present in a non-empty proxySpellPool
+                    if (proxySpellPool != SpellPool.empty) {
+                        if (!proxySpellPool.spellIds().contains(other.id())) {
+                            toRemove.add(other.id().toString());
+                        }
+                    }
                 }
             }
         }
         spellIds.removeAll(toRemove);
 
-        return new SpellContainer(proxyContainer.content(), false, null, 0, new ArrayList<>(spellIds));
+        return new SpellContainer(proxyContainer.content(), false, null, null, 0, new ArrayList<>(spellIds));
     }
 
     private static boolean isOffhandContainerValid(PlayerEntity player, SpellContainer.ContentType allowedContent) {

--- a/src/main/java/net/spell_engine/utils/WeaponCompatibility.java
+++ b/src/main/java/net/spell_engine/utils/WeaponCompatibility.java
@@ -14,8 +14,8 @@ import java.util.regex.Pattern;
 public class WeaponCompatibility {
     public static void initialize() {
         var config = SpellEngineMod.config;
-        var spellProxyContainer = new SpellContainer(SpellContainer.ContentType.MAGIC, true, null, 0, List.of());
-        var arrowProxyContainer = new SpellContainer(SpellContainer.ContentType.ARCHERY, true, null, 0, List.of());
+        var spellProxyContainer = new SpellContainer(SpellContainer.ContentType.MAGIC, true, null, null, 0, List.of());
+        var arrowProxyContainer = new SpellContainer(SpellContainer.ContentType.ARCHERY, true, null, null, 0, List.of());
         for(var itemId: Registries.ITEM.getIds()) {
             var itemIdString = itemId.toString();
             if (matches(itemIdString, config.blacklist_spell_casting_regex)) {


### PR DESCRIPTION
Proxy_pools act as a whitelist for spells that the spell proxy item can cast.
They are an optional feature, no existing content should need an update.

However they give mod/data pack authors more options when designing and balancing their content when using the Spell Engine API.