### PR TITLE
Added support for base power and base heal

### DIFF
--- a/src/main/java/net/spell_engine/api/spell/Spell.java
+++ b/src/main/java/net/spell_engine/api/spell/Spell.java
@@ -182,11 +182,13 @@ public class Spell {
             public static class Damage { public Damage() { }
                 public boolean bypass_iframes = true;
                 public float spell_power_coefficient = 1;
+                public float base_power = 0;
                 public float knockback = 1;
             }
             public Heal heal;
             public static class Heal { public Heal() { }
                 public float spell_power_coefficient = 1;
+                public float base_heal = 0;
             }
             public StatusEffect status_effect;
             public static class StatusEffect { public StatusEffect() { }


### PR DESCRIPTION
Base power and base heal would be multiplied by the total modifier to flat attribute and then added to spell power before being multiplied by the coefficient.

The resulting equation would be: 
Damage = (Base Damage + Flat Attribute) * multiplicative bonuses * coefficient

The reasoning behind this change would be to open up balancing options revolving around a base damage which would be dealt with zero spell power, allowing players such as paladins to do decent damage or healing without having large amounts of spell power. This would also eliminate the need for flat spell power on weapons, allowing there to simply only be multiplicative bonuses everywhere.

My suggestion is to combine this change with a replacement of flat spell power on staves with percentage increases, addition of four base power to all spells, and reduction in all existing percentage bonuses by 50%. 