### PR TITLE
FTB Teams integration into EntityRelations#getRelation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,25 @@ repositories {
         name = "Ladysnake Libs"
         url = 'https://maven.ladysnake.org/releases'
     }
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = "https://maven.ftb.dev/releases"
+            }
+        }
+        filter {
+            includeGroup"dev.latvian.mods"
+            includeGroup"dev.ftb.mods"
+        }
+    }
+    // JEI Maven currently required by FTB
+    maven {
+        name "ModMaven (JEI)"
+        url "https://modmaven.dev/"
+        content {
+            includeGroup "mezz.jei"
+        }
+    }
 }
 
 loom {
@@ -75,6 +94,8 @@ dependencies {
     modCompileOnly("maven.modrinth:better-combat:${project.better_combat_version}")
     modImplementation("maven.modrinth:combat-roll:${project.combat_roll_version}")
     modImplementation("maven.modrinth:bundle-api:${project.bundle_api_version}")
+    modCompileOnly("dev.ftb.mods:ftb-teams-fabric:${project.ftb_teams_version}")
+    modCompileOnly("dev.ftb.mods:ftb-library-fabric:${project.ftb_library_version}")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,3 +34,7 @@ better_combat_version=2.1.3+1.21.1-fabric
 
 # For roll event subscription
 combat_roll_version=2.0.2+1.21.1-fabric
+
+## FTB Teams
+ftb_teams_version=2101.1.2
+ftb_library_version=2101.1.7

--- a/src/main/java/net/spell_engine/internals/target/EntityRelations.java
+++ b/src/main/java/net/spell_engine/internals/target/EntityRelations.java
@@ -1,11 +1,15 @@
 package net.spell_engine.internals.target;
 
+import dev.ftb.mods.ftbteams.api.FTBTeamsAPI;
+import dev.ftb.mods.ftbteams.api.TeamManager;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.Tameable;
 import net.minecraft.entity.decoration.AbstractDecorationEntity;
 import net.minecraft.entity.mob.HostileEntity;
 import net.minecraft.entity.passive.PassiveEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.Registries;
 import net.minecraft.scoreboard.AbstractTeam;
 import net.spell_engine.SpellEngineMod;
@@ -31,6 +35,20 @@ public class EntityRelations {
         }
         var config = SpellEngineMod.config;
         if (casterTeam == null || targetTeam == null) {
+            // --- FTB TEAMS ---
+            if (FabricLoader.getInstance().isModLoaded("ftbteams") && attacker instanceof PlayerEntity attackerPlayer && target instanceof PlayerEntity targetPlayer) {
+                boolean managerAvailable = attacker.getWorld().isClient ?
+                        FTBTeamsAPI.api().isClientManagerLoaded() :
+                        FTBTeamsAPI.api().isManagerLoaded();
+                if (managerAvailable) {
+                    TeamManager manager = FTBTeamsAPI.api().getManager();
+                    if (manager.arePlayersInSameTeam(attackerPlayer.getUuid(), targetPlayer.getUuid())) {
+                        return EntityRelation.ALLY;
+                    }
+                }
+            }
+            // --- END FTB TEAMS ---
+
             var id = Registries.ENTITY_TYPE.getId(target.getType());
             var mappedRelation = config.player_relations.get(id.toString());
             if (mappedRelation != null) {


### PR DESCRIPTION
Symmetric to https://github.com/ZsoltMolnarrr/BetterCombat/pull/483

Return `FRIENDLY` if FTB Teams is loaded and the players are on the same FTB Team

Should also work with the existing recursive Tameable check


*Note:*
FTB Teams does not seem to have a "friendly fire toggle" property I can find, so the check always returns friendly if players are on the same team.