### PR TITLE
Fix NPE with Trinkets compat when players die

### DIFF
--- a/src/main/java/net/spell_engine/compat/TrinketsCompat.java
+++ b/src/main/java/net/spell_engine/compat/TrinketsCompat.java
@@ -58,7 +58,14 @@ public class TrinketsCompat {
         var trinketComponent = component.get();
         var allowedContent = proxyContainer.content;
         var items = new LinkedHashSet<ItemStack>();
-        var spellBookSlot = trinketComponent.getInventory().get("charm").get("spell_book");
+        var charm = trinketComponent.getInventory().get("charm");
+        if(charm == null) {
+            return Collections.emptyList();
+        }
+        var spellBookSlot = charm.get("spell_book");
+        if(spellBookSlot == null) {
+            return Collections.emptyList();
+        }
 
         // Add the spell book slot first
         items.add(spellBookSlot.getStack(0));


### PR DESCRIPTION
**Note that this is for the 1.20.1 branch.**

When players die, occasionally, this crashes the server due to an NPE where the charm slot is null. I presume this is because the player is dead the slots are no longer present at the time they are requested. Here's the link to the crash report: https://mclo.gs/WY8U1RI

This is definitely a band-aid fix, and might be more suitably resolved by returning the `proxyContainer` in `SpellContainerHelper#getEquipped` when the `player` is dead. Though I am not familiar enough with your codebase to say for sure.
https://github.com/ZsoltMolnarrr/SpellEngine/blob/9eaa8c7dc3e6827c3171310e3bc517e3d35090b6/src/main/java/net/spell_engine/internals/SpellContainerHelper.java#L42-L46

I made this change to patch the issue on a server I'm running and figured I might as well submit a PR to fix it for you. Feel free to make any changes to this!