### PR TITLE
autoRelease config. Fixed usekey not stopping spells when hotkey doesn't need to be held.

### DIFF
--- a/common/src/main/java/net/spell_engine/client/input/SpellHotbar.java
+++ b/common/src/main/java/net/spell_engine/client/input/SpellHotbar.java
@@ -229,6 +229,21 @@ public class SpellHotbar {
                             var needsToBeHeld = SpellHelper.isChanneled(casted.process().spell().value()) ?
                                     SpellEngineClient.config.holdToCastChannelled :
                                     SpellEngineClient.config.holdToCastCharged;
+                            if(slot.castMode().equals(SpellCast.Mode.CASTING)&& !SpellEngineClient.config.autoRelease && casted.process().progress(player.getWorld().getTime()) .ratio() >= 1){
+                                if ((!pressed && needsToBeHeld)
+                                        || (pressed && !needsToBeHeld
+                                        && isReleased(keyBinding, UseCase.START))) {
+                                    caster.releaseCharge();
+
+                                    if (!needsToBeHeld) {
+                                        debounce(keyBinding, UseCase.STOP);
+                                    }
+
+                                    handledThisTick = handle;
+                                    return handle;
+                                }
+                            }
+                            else
                             if (needsToBeHeld) {
                                 if (!pressed) {
                                     caster.cancelSpellCast();
@@ -258,7 +273,7 @@ public class SpellHotbar {
                     case CHARGED -> {
                         if (casted != null && casted.process().id().equals(slot.spell.getKey().get().getValue())) {
                             // The spell is already being charged
-                            if (SpellEngineClient.config.holdToCastCharged) {
+                            if (SpellEngineClient.config.holdToCastCharged ) {
                                 if (!pressed) {
                                     caster.releaseCharge();
                                     handledThisTick = handle;

--- a/common/src/main/java/net/spell_engine/config/ClientConfig.java
+++ b/common/src/main/java/net/spell_engine/config/ClientConfig.java
@@ -8,6 +8,8 @@ import net.spell_engine.client.input.WrappedKeybinding;
 @Config(name = "client")
 public class ClientConfig implements ConfigData {
     @ConfigEntry.Gui.Tooltip
+    public boolean autoRelease = true;
+    @ConfigEntry.Gui.Tooltip
     public boolean renderBeamsHighLuminance = true;
     @ConfigEntry.Gui.Tooltip
     public boolean holdToCastChannelled = true;

--- a/common/src/main/java/net/spell_engine/mixin/client/ClientPlayerEntityMixin.java
+++ b/common/src/main/java/net/spell_engine/mixin/client/ClientPlayerEntityMixin.java
@@ -223,7 +223,7 @@ public abstract class ClientPlayerEntityMixin implements SpellCasterClient {
                 var isFinished = spellCastTicks >= process.length();
                 // CHARGE spells are not auto-released at full: the player may hold the charge
                 // indefinitely and releases manually (key-up, via SpellHotbar -> releaseCharge).
-                if (isFinished && cast.resolvedType() != Spell.Active.Cast.Type.CHARGE) {
+                if (isFinished && (cast.resolvedType() != Spell.Active.Cast.Type.CHARGE && SpellEngineClient.config.autoRelease)) {
                     // Release spell
                     releaseSpellCast(process, SpellCast.Action.RELEASE);
                 }

--- a/common/src/main/java/net/spell_engine/mixin/client/ClientPlayerEntityMixin.java
+++ b/common/src/main/java/net/spell_engine/mixin/client/ClientPlayerEntityMixin.java
@@ -223,8 +223,12 @@ public abstract class ClientPlayerEntityMixin implements SpellCasterClient {
                 var isFinished = spellCastTicks >= process.length();
                 // CHARGE spells are not auto-released at full: the player may hold the charge
                 // indefinitely and releases manually (key-up, via SpellHotbar -> releaseCharge).
-                if (isFinished && (cast.resolvedType() != Spell.Active.Cast.Type.CHARGE && SpellEngineClient.config.autoRelease)) {
-                    // Release spell
+                boolean shouldAutoRelease =
+                        process.length() <= 0 || SpellEngineClient.config.autoRelease;
+
+                if (isFinished
+                        && cast.resolvedType() != Spell.Active.Cast.Type.CHARGE
+                        && shouldAutoRelease) {
                     releaseSpellCast(process, SpellCast.Action.RELEASE);
                 }
             }

--- a/common/src/main/java/net/spell_engine/mixin/client/control/SpellHotbarMinecraftClient.java
+++ b/common/src/main/java/net/spell_engine/mixin/client/control/SpellHotbarMinecraftClient.java
@@ -84,12 +84,17 @@ public abstract class SpellHotbarMinecraftClient implements MinecraftClientExten
                 player.stopUsingItem();
                 itemUseCooldown = 1;
             }
-            if ( (handled.isSuccessfulAttempt() || ((SpellCasterClient)player).isCastingSpell())
-                    && handled.keyBinding() == options.useKey) {
-                useKeySpellCastingLock = true;
+            if (handled != null && handled.keyBinding() == options.useKey) {
+                if (handled.isSuccessfulAttempt()
+                        || ((SpellCasterClient) player).isCastingSpell()
+                        || handled.attempt() == null) {
+                    useKeySpellCastingLock = true;
+                }
             }
         }
-        if (useKeySpellCastingLock && !options.useKey.isPressed()) {
+        if (useKeySpellCastingLock
+                && !options.useKey.isPressed()
+                && !((SpellCasterClient) player).isCastingSpell()) {
             useKeySpellCastingLock = false;
         }
         if (((SpellCasterClient)player).isCastingSpell()) {

--- a/common/src/main/resources/assets/spell_engine/lang/en_us.json
+++ b/common/src/main/resources/assets/spell_engine/lang/en_us.json
@@ -121,7 +121,8 @@
   "effect.spell_engine.energy.description": "The held weapon burns with energy.",
 
   "text.autoconfig.spell_engine.title" : "Spell Engine",
-
+  "text.autoconfig.spell_engine.option.client.autoRelease" : "Auto Release",
+  "text.autoconfig.spell_engine.option.client.autoRelease.@Tooltip" : "As soon as spells are done casting, release if possible. Does not affect CHARGED or CHANNELED spells.",
   "text.autoconfig.spell_engine.option.client.renderBeamsHighLuminance" : "High luminance beams",
   "text.autoconfig.spell_engine.option.client.renderBeamsHighLuminance.@Tooltip" : "Render spell beams with high luminance, for better spectacular visual effects",
   "text.autoconfig.spell_engine.option.client.holdToCastChannelled" : "Hold to cast CHANNELLED spells",


### PR DESCRIPTION
There was an unresolved bug when spells didn't need to have their hotkeys held via config - if a spell was bound to useKey (AKA rightclick) it couldn't be manually cancelled. This fixes that.

I also added an option for an AutoRelease config feature, where you can turn it off so that you can manually allow spells to resolve rather than casting immediately upon a spell finishing its cast. This allows people to "hold" their spells, for example if they want to turn a corner with a spell's cast time already prepared. I don't know if you want that for balance but I imagine a decent amount of people would actually like to use it.

I have tested both the fix and the feature and they both work. 